### PR TITLE
Reverting GoogleAdSdk update to 8.8.0

### DIFF
--- a/GoogleMobileAds/GoogleMobileAds.json
+++ b/GoogleMobileAds/GoogleMobileAds.json
@@ -1,6 +1,5 @@
 {
 	"7.30.0": "https://github.com/dowjones-mobile/external-binaries/raw/master/GoogleMobileAds/GoogleMobileAdsSdkiOS-7.30.0-1.zip",
 	"7.61.0": "https://github.com/dowjones-mobile/external-binaries/raw/master/GoogleMobileAds/GoogleMobileAdsSdkiOS-7.61.0.zip",
-	"7.64.0": "https://github.com/dowjones-mobile/external-binaries/raw/master/GoogleMobileAds/GoogleMobileAdsSdkiOS-7.64.0.zip",
-	"8.8.0": "https://github.com/dowjones-mobile/external-binaries/raw/master/GoogleMobileAds/GoogleMobileAdsSdkiOS-8.8.0.zip"
+	"7.64.0": "https://github.com/dowjones-mobile/external-binaries/raw/master/GoogleMobileAds/GoogleMobileAdsSdkiOS-7.64.0.zip"
 }

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "GoogleMobileAds",
-            path: "GoogleMobileAds/8.8.0/GoogleMobileAds.xcframework"
+            path: "GoogleMobileAds/7.69.0/GoogleMobileAds.xcframework"
         ),
         .binaryTarget(
             name: "GoogleAppMeasurement",


### PR DESCRIPTION
I am reverting the changes in package.swift and json file as it could be an issue for current build.